### PR TITLE
Fixing set_rich_header_info.

### DIFF
--- a/PEAnalyser.py
+++ b/PEAnalyser.py
@@ -519,8 +519,9 @@ class PEAnalyser():
             for i in range(0, len(getattr(self.pe.RICH_HEADER, 'values', [])), 2):
                 comp_id = self.pe.RICH_HEADER.values[i]
                 comp_cnt = self.pe.RICH_HEADER.values[i + 1]
-                comp_name = self.__COMPID_DICT.get(comp_id, '*unknown*')
-                rich_header.append({"id" : comp_id, "count" : comp_cnt, "name" : comp_name})
+                comp_name = self.__COMPID_DICT.get((comp_id & 0xffff0000) >> 16, '*unknown*')
+                comp_build = comp_id & 0xffff
+                rich_header.append({"id" : comp_id, "count" : comp_cnt, "name" : comp_name, "build" : comp_build})
             if len(rich_header) != 0:
                 self.info['PE']['RichHeader'] = rich_header
 


### PR DESCRIPTION
Fixing ``set_rich_header_info``. The variable ``comp_id`` includes two values: the highest two bytes are the name "prodID", the lowest two bytes are the build number (see https://www.virusbulletin.com/uploads/pdf/magazine/2019/VB2019-Kalnai-Poslusny.pdf). In this commit, the  identification of the ``comp_name`` value has been fixed, and the value of the build number (``comp_build``) has been added.